### PR TITLE
Feature/register related

### DIFF
--- a/contracts/Nengajo.sol
+++ b/contracts/Nengajo.sol
@@ -28,10 +28,10 @@ contract Nengajo is ERC1155, ERC1155Supply, ERC1155URIStorage, MintManager {
     function registerCreative(uint256 _maxSupply, string memory _metaDataURL)
         public
     {
-        _tokenIds.increment();
         uint256 tokenId = _tokenIds.current();
         _setURI(tokenId, _metaDataURL);
         maxSupply[tokenId] = _maxSupply;
+        _tokenIds.increment();
     }
 
     function mint(uint256 _tokenId) public {

--- a/test/nengajo.ts
+++ b/test/nengajo.ts
@@ -21,24 +21,70 @@ describe('CreateNengajo', () => {
   })
 
   it('register creative', async () => {
-    await NengajoContract.connect(creator).registerCreative(1, 'ipfs://test1')
+    await NengajoContract.connect(creator).registerCreative(2, 'ipfs://test1')
     const tokenURI = await NengajoContract.uri(0)
     expect(tokenURI).equal('ipfs://test1')
+
+    const getAllRegisteredNengajos = await NengajoContract.getAllRegisteredNengajos()
+    expect(getAllRegisteredNengajos.length).to.equal(1)
+    expect(getAllRegisteredNengajos[0].uri).to.equal('ipfs://test1')
+    expect(getAllRegisteredNengajos[0].creator).to.equal(creator.address)
+    expect(getAllRegisteredNengajos[0].maxSupply).to.equal(2)
+
+    const getRegisteredNengajo = await NengajoContract.getRegisteredNengajo(0)
+    expect(getRegisteredNengajo.uri).to.equal('ipfs://test1')
+    expect(getRegisteredNengajo.creator).to.equal(creator.address)
+    expect(getRegisteredNengajo.maxSupply).to.equal(2)
   })
 
   it('mint nengajo', async () => {
     await(await NengajoContract.connect(deployer).switchMintable())
     await NengajoContract.connect(user1).mint(0)
-    const balance = await NengajoContract.connect(user1).balanceOf(
+    let balance = await NengajoContract.connect(user1).balanceOf(
       user1.address,
       0
     )
-    expect(balance).equal(1)
+    expect(balance).to.equal(1)
+
+    let getAllRegisteredNengajos = await NengajoContract.getAllRegisteredNengajos()
+    expect(getAllRegisteredNengajos.length).to.equal(1)
+    expect(getAllRegisteredNengajos[0].uri).to.equal('ipfs://test1')
+    expect(getAllRegisteredNengajos[0].creator).to.equal(creator.address)
+    expect(getAllRegisteredNengajos[0].maxSupply).to.equal(2)
+
+    let getRegisteredNengajo = await NengajoContract.getRegisteredNengajo(0)
+    expect(getRegisteredNengajo.uri).to.equal('ipfs://test1')
+    expect(getRegisteredNengajo.creator).to.equal(creator.address)
+    expect(getRegisteredNengajo.maxSupply).to.equal(2)
+    
+    await NengajoContract.connect(user2).mint(0)
+    balance = await NengajoContract.connect(user2).balanceOf(
+      user2.address,
+      0
+    )
+    expect(balance).to.equal(1)
+
+    getAllRegisteredNengajos = await NengajoContract.getAllRegisteredNengajos()
+    expect(getAllRegisteredNengajos.length).to.equal(1)
+    expect(getAllRegisteredNengajos[0].uri).to.equal('ipfs://test1')
+    expect(getAllRegisteredNengajos[0].creator).to.equal(creator.address)
+    expect(getAllRegisteredNengajos[0].maxSupply).to.equal(2)
+
+    getRegisteredNengajo = await NengajoContract.getRegisteredNengajo(0)
+    expect(getRegisteredNengajo.uri).to.equal('ipfs://test1')
+    expect(getRegisteredNengajo.creator).to.equal(creator.address)
+    expect(getRegisteredNengajo.maxSupply).to.equal(2)
   })
 
   it('failed with unavailable', async () => {
     await expect(NengajoContract.connect(user2).mint(1)).to.be.revertedWith(
       'not available'
+    )
+  })
+
+  it('failed with mint limit', async () => {
+    await expect(NengajoContract.connect(user2).mint(0)).to.be.revertedWith(
+      'mint limit reached'
     )
   })
 })

--- a/test/nengajo.ts
+++ b/test/nengajo.ts
@@ -22,16 +22,16 @@ describe('CreateNengajo', () => {
 
   it('register creative', async () => {
     await NengajoContract.connect(creator).registerCreative(1, 'ipfs://test1')
-    const tokenURI = await NengajoContract.uri(1)
+    const tokenURI = await NengajoContract.uri(0)
     expect(tokenURI).equal('ipfs://test1')
   })
 
   it('mint nengajo', async () => {
     await(await NengajoContract.connect(deployer).switchMintable())
-    await NengajoContract.connect(user1).mint(1)
+    await NengajoContract.connect(user1).mint(0)
     const balance = await NengajoContract.connect(user1).balanceOf(
       user1.address,
-      1
+      0
     )
     expect(balance).equal(1)
   })
@@ -229,7 +229,7 @@ describe('after minting term', () => {
     const checkRemainingCloseTime = await NengajoContract.callStatic.checkRemainingCloseTime()
 
     await NengajoContract.connect(creator).registerCreative(1, 'ipfs://test1')
-    const tokenURI = await NengajoContract.uri(1)
+    const tokenURI = await NengajoContract.uri(0)
     expect(tokenURI).equal('ipfs://test1')
 
     let mintable
@@ -237,7 +237,7 @@ describe('after minting term', () => {
     expect(mintable).to.equal(false)
 
     if (checkRemainingOpenTime || !checkRemainingCloseTime && !mintable) {
-      await expect(NengajoContract.connect(user1).mint(1)).to.be.revertedWith(
+      await expect(NengajoContract.connect(user1).mint(0)).to.be.revertedWith(
         'not minting time and not mintable'
       )
     }


### PR DESCRIPTION
Issue #4 Implement a function for registering nengajo and retrieving registered nengajoes
の上4つを実装してみました。
- Consider nengajo struct
- implement listing function
- implement retrieving lited nengajoes function
- limit num of max supply for each nengajo

大きな変更点としては、
- `struct NengajoInfo`を型に`registeredNengajos`配列を追加し、以下の3つを入れた
  - uri
  - creatorのアドレス
  - maxSupply
- `ERC1155URIStorage`の継承を削除し、`registeredNengajos`の`uri`を参照するように変更
- `maxSupply`のmappingを削除し、`registeredNengajos`の`maxSupply`から参照するように変更
- 配列を活用できるように、`_tokenIds`の開始IDを`1`から`0`に変更