### PR TITLE
feat: add retrievedMintedNengajo

### DIFF
--- a/contracts/Nengajo.sol
+++ b/contracts/Nengajo.sol
@@ -8,18 +8,22 @@ import "./InteractHenkakuToken.sol";
 
 contract Nengajo is ERC1155, ERC1155Supply, MintManager, InteractHenakuToken {
 
-    //登録された年賀状と作成者の情報は、０からカウントアップされて_tokenIdsに保存される
+    //@dev count up tokenId from 0
     using Counters for Counters.Counter;
     Counters.Counter private _tokenIds;
 
     string public name;
     string public symbol;
 
-    // Nengajo Creator's info
+    /**
+     * @param uri: metadata uri
+     * @param creator: creator's wallet address
+     * @param maxSupply: max supply number of token
+     */
     struct NengajoInfo {
-        string uri;         // image address
-        address creator;    // creator's wallet address
-        uint256 maxSupply;  // maxium number of mint
+        string uri;
+        address creator;
+        uint256 maxSupply;
     }
 
     NengajoInfo[] private registeredNengajos;
@@ -50,6 +54,7 @@ contract Nengajo is ERC1155, ERC1155Supply, MintManager, InteractHenakuToken {
         _tokenIds.increment();
     }
 
+    // @return all registered nangajo
     function getAllRegisteredNengajos()
         external
         view
@@ -58,6 +63,7 @@ contract Nengajo is ERC1155, ERC1155Supply, MintManager, InteractHenakuToken {
         return registeredNengajos;
     }
 
+    // @return registered nengajo data
     function getRegisteredNengajo(uint256 _tokenId)
         public
         view
@@ -67,7 +73,7 @@ contract Nengajo is ERC1155, ERC1155Supply, MintManager, InteractHenakuToken {
         return registeredNengajos[_tokenId];
     }
 
-    // ミントする関数
+    // @dev mint function
     function mint(uint256 _tokenId) public {
         require(
             (block.timestamp > open_blockTimestamp &&
@@ -84,9 +90,9 @@ contract Nengajo is ERC1155, ERC1155Supply, MintManager, InteractHenakuToken {
 
         // ミントした_tokenIdsを保存する
         mintedNengajoList[msg.sender].push(_tokenId);
-
     }
 
+    // @return token metadata uri
     function uri(uint256 _tokenId)
         public
         view
@@ -96,8 +102,7 @@ contract Nengajo is ERC1155, ERC1155Supply, MintManager, InteractHenakuToken {
         return getRegisteredNengajo(_tokenId).uri;
     }
 
-    // msg.sender情報からミントした年賀状の_tokenIdsを配列で返す関数
-    //      作成者 sushi yam
+    // @return holding tokenIds with address
     function retrieveMintedNengajo()
         public
         view

--- a/contracts/Nengajo.sol
+++ b/contracts/Nengajo.sol
@@ -7,19 +7,26 @@ import "./MintManager.sol";
 import "./InteractHenkakuToken.sol";
 
 contract Nengajo is ERC1155, ERC1155Supply, MintManager, InteractHenakuToken {
+
+    //登録された年賀状と作成者の情報は、０からカウントアップされて_tokenIdsに保存される
     using Counters for Counters.Counter;
     Counters.Counter private _tokenIds;
 
     string public name;
     string public symbol;
 
+    // Nengajo Creator's info
     struct NengajoInfo {
-        string uri;
-        address creator;
-        uint256 maxSupply;
+        string uri;         // image address
+        address creator;    // creator's wallet address
+        uint256 maxSupply;  // maxium number of mint
     }
 
     NengajoInfo[] private registeredNengajos;
+
+    // Nengajo Minter's info
+    //addressがkey、uintがvalue、mintedNengajoListは格納する変数
+    mapping(address => uint256[]) public mintedNengajoList;
 
     constructor(
         string memory _name,
@@ -60,6 +67,7 @@ contract Nengajo is ERC1155, ERC1155Supply, MintManager, InteractHenakuToken {
         return registeredNengajos[_tokenId];
     }
 
+    // ミントする関数
     function mint(uint256 _tokenId) public {
         require(
             (block.timestamp > open_blockTimestamp &&
@@ -73,6 +81,10 @@ contract Nengajo is ERC1155, ERC1155Supply, MintManager, InteractHenakuToken {
             "Nengajo: Mint limit reached"
         );
         _mint(msg.sender, _tokenId, 1, "");
+
+        // ミントした_tokenIdsを保存する
+        mintedNengajoList[msg.sender].push(_tokenId);
+
     }
 
     function uri(uint256 _tokenId)
@@ -82,6 +94,16 @@ contract Nengajo is ERC1155, ERC1155Supply, MintManager, InteractHenakuToken {
         returns (string memory)
     {
         return getRegisteredNengajo(_tokenId).uri;
+    }
+
+    // msg.sender情報からミントした年賀状の_tokenIdsを配列で返す関数
+    //      作成者 sushi yam
+    function retrieveMintedNengajo()
+        public
+        view
+        returns (uint256[] memory)
+    {
+        return mintedNengajoList[msg.sender];
     }
 
     function _beforeTokenTransfer(

--- a/test/nengajo.ts
+++ b/test/nengajo.ts
@@ -77,39 +77,38 @@ describe('CreateNengajo', () => {
 
   it('mint nengajo', async () => {
     await NengajoContract.connect(deployer).switchMintable()
+    
     await NengajoContract.connect(user1).mint(0)
     let balance = await NengajoContract.connect(user1).balanceOf(user1.address, 0)
     expect(balance).to.equal(1)
-
-    let getAllRegisteredNengajos = await NengajoContract.getAllRegisteredNengajos()
-    expect(getAllRegisteredNengajos.length).to.equal(1)
-    expect(getAllRegisteredNengajos[0].uri).to.equal('ipfs://test1')
-    expect(getAllRegisteredNengajos[0].creator).to.equal(creator.address)
-    expect(getAllRegisteredNengajos[0].maxSupply).to.equal(2)
-
-    let getRegisteredNengajo = await NengajoContract.getRegisteredNengajo(0)
-    expect(getRegisteredNengajo.uri).to.equal('ipfs://test1')
-    expect(getRegisteredNengajo.creator).to.equal(creator.address)
-    expect(getRegisteredNengajo.maxSupply).to.equal(2)
 
     await NengajoContract.connect(user2).mint(0)
     balance = await NengajoContract.connect(user2).balanceOf(user2.address, 0)
     expect(balance).to.equal(1)
 
-    getAllRegisteredNengajos = await NengajoContract.getAllRegisteredNengajos()
-    expect(getAllRegisteredNengajos.length).to.equal(1)
-    expect(getAllRegisteredNengajos[0].uri).to.equal('ipfs://test1')
-    expect(getAllRegisteredNengajos[0].creator).to.equal(creator.address)
-    expect(getAllRegisteredNengajos[0].maxSupply).to.equal(2)
+  })
 
-    getRegisteredNengajo = await NengajoContract.getRegisteredNengajo(0)
-    expect(getRegisteredNengajo.uri).to.equal('ipfs://test1')
-    expect(getRegisteredNengajo.creator).to.equal(creator.address)
-    expect(getRegisteredNengajo.maxSupply).to.equal(2)
+  it('retrieve minted nengajo', async () => {
+
+    // ミントされた年賀状の確認
+    // user1のミントした
+    let mintedNengajo = await NengajoContract.connect(user1).retrieveMintedNengajo()
+    expect(mintedNengajo[0]).to.equal(0)
+    await NengajoContract.connect(creator).registerCreative(2, 'ipfs://test1')
+
+    // user1が年賀状を２枚め(_tokenIdが１)をミント
+    await NengajoContract.connect(user1).mint(1)
+    mintedNengajo = await NengajoContract.connect(user1).retrieveMintedNengajo()
+
+    expect(mintedNengajo[0]).to.equal(0)
+    expect(mintedNengajo[1]).to.equal(1)
+
   })
 
   it('failed with unavailable', async () => {
-    await expect(NengajoContract.connect(user2).mint(1)).to.be.revertedWith('Nengajo: not available')
+
+    // await expect(NengajoContract.connect(user2).mint(1)).to.be.revertedWith('Nengajo: not available')
+    await expect(NengajoContract.connect(user2).mint(5)).to.be.revertedWith('Nengajo: not available')
   })
 
   it('failed with already have', async () => {


### PR DESCRIPTION
1. ミントした_tokenIdsを保存する機能をmint関数内に実装
2. msg.sender情報からミントした年賀状の_tokenIdsを配列で返す関数を追加
3. テストファイルにミントされた年賀状の確認機能を追加
