### PR TITLE
feat: add delete admin function

### DIFF
--- a/contracts/MintManager.sol
+++ b/contracts/MintManager.sol
@@ -34,6 +34,10 @@ abstract contract MintManager {
         }
     }
 
+    function deleteAdmin(address _deleteAdmin) external onlyAdmins {
+        admins[_deleteAdmin] = false;
+    }
+
     function switchMintable() external onlyAdmins {
         mintable = !mintable;
     }

--- a/test/nengajo.ts
+++ b/test/nengajo.ts
@@ -386,6 +386,18 @@ describe('CheckMintable', () => {
     expect(isAdmin).to.equal(true)
   })
 
+  it('delete an admin', async () => {
+    let isAdmin
+    isAdmin = await NengajoContract.admins(user2.address)
+    expect(isAdmin).to.equal(true)
+
+    const deleteAdmin = await NengajoContract.connect(deployer).deleteAdmin(user2.address)
+    await deleteAdmin.wait()
+
+    isAdmin = await NengajoContract.admins(user2.address)
+    expect(isAdmin).to.equal(false)
+  })
+
   it('switch mintable flag', async () => {
     let mintable
     mintable = await NengajoContract.mintable()


### PR DESCRIPTION
- MintManger.solにadminを削除する`deleteAdmin()`を追加
- `deleteAmin()`のテストを追加

を実装しました！

`deleteAdmin()`も`addAdmins()`と同様にfor文で複数削除できるようにしようかとも考えたのですが、緊急的な用途だと判断したため、複数削除は採用しませんでした！

ご確認お願いします！