### PR TITLE
feat: change register price calculation

### DIFF
--- a/contracts/Nengajo.sol
+++ b/contracts/Nengajo.sol
@@ -67,22 +67,7 @@ contract Nengajo is ERC1155, ERC1155Supply, Administration, MintManager, Interac
 
     function registerNengajo(uint256 _maxSupply, string memory _metaDataURL) public {
         require(_maxSupply != 0 || keccak256(bytes(_metaDataURL)) != keccak256(bytes("")), "Nengajo: invalid params");
-        NengajoInfo[] memory _registeredNengajoes = registeredNengajoes;
-        uint256[] memory _ownerOfRegisteredIds = ownerOfRegisteredIds[msg.sender];
-        uint256 registeredCount;
-        for (uint256 i = 0; i < _ownerOfRegisteredIds.length; ) {
-            registeredCount += _registeredNengajoes[_ownerOfRegisteredIds[i]].maxSupply;
-            unchecked {
-                ++i;
-            }
-        }
-
-        uint256 amount = 1;
-        if (registeredCount > 5) {
-            amount = _maxSupply * 10;
-        } else if (registeredCount + _maxSupply > 5) {
-            amount = (registeredCount + _maxSupply - 5) * 10;
-        }
+        uint256 amount = calcPrice(_maxSupply);
 
         uint256 tokenId = _tokenIds.current();
         ownerOfRegisteredIds[msg.sender].push(tokenId);
@@ -94,6 +79,28 @@ contract Nengajo is ERC1155, ERC1155Supply, Administration, MintManager, Interac
         // @dev Emit registeredNengajo
         // @param address, tokenId, URL of meta data, max supply
         emit RegisterNengajo(msg.sender, tokenId, _metaDataURL, _maxSupply);
+    }
+
+    function calcPrice(uint256 _maxSupply) public view returns (uint256) {
+        NengajoInfo[] memory _registeredNengajoes = registeredNengajoes;
+        uint256[] memory _ownerOfRegisteredIds = ownerOfRegisteredIds[msg.sender];
+        uint256 registeredCount;
+        for (uint256 i = 0; i < _ownerOfRegisteredIds.length; ) {
+            registeredCount += _registeredNengajoes[_ownerOfRegisteredIds[i]].maxSupply;
+            unchecked {
+                ++i;
+            }
+        }
+        uint256 amount;
+        uint256 totalMaxSupply = registeredCount + _maxSupply;
+        if (totalMaxSupply <= 10) {
+            amount = 10;
+        } else if (10 < totalMaxSupply || totalMaxSupply < 101) {
+            amount = totalMaxSupply * 5 - 40;
+        } else {
+            amount = totalMaxSupply * 10 - 540;
+        }
+        return amount;
     }
 
     // @return all registered NengajoInfo

--- a/test/nengajo.ts
+++ b/test/nengajo.ts
@@ -35,11 +35,14 @@ const calcRequiredHenkakuForRegister: (params: {
     },
     0
   )
-  let amount = 1
-  if (registeredCount > 5) {
-    amount = maxSupply * 10
-  } else if (registeredCount + maxSupply > 5) {
-    amount = (registeredCount + maxSupply - 5) * 10
+  let amount
+  let totalMaxSupply = registeredCount + maxSupply
+  if (totalMaxSupply <= 10) {
+    amount = 10
+  } else if (10 < totalMaxSupply || totalMaxSupply < 101) {
+    amount = totalMaxSupply * 5 - 40
+  } else {
+    amount = totalMaxSupply * 10 - 540
   }
   return amount
 }
@@ -58,7 +61,7 @@ describe('RegisterNengajo', () => {
     HenkakuTokenContract = await deployAndDistributeHenkakuV2({
       deployer,
       addresses: [creator.address, user1.address, user2.address, user3.address, deployer.address],
-      amount: 100,
+      amount: 1000,
     })
     const NengajoFactory = await ethers.getContractFactory('Nengajo')
     NengajoContract = await NengajoFactory.deploy(
@@ -123,15 +126,12 @@ describe('RegisterNengajo', () => {
 
   it('check 1Henkaku transfered', async () => {
     const henkakuBalance = await HenkakuTokenContract.balanceOf(creator.address)
-    expect(henkakuBalance).to.equal(99)
+    expect(henkakuBalance).to.equal(990)
   })
 
   it('failed register nengajo with insufficient henkaku token', async () => {
     // Nengajo registration is reverted.
     // 年賀状の登録がリバートされる
-    await expect(NengajoContract.connect(creator).registerNengajo(15, 'ipfs://test1')).to.be.revertedWith(
-      'Nengajo: Insufficient HenkakuV2 token'
-    )
     await expect(NengajoContract.connect(creator).registerNengajo(1000, 'ipfs://test1')).to.be.revertedWith(
       'Nengajo: Insufficient HenkakuV2 token'
     )


### PR DESCRIPTION
#13 Consider an algorithm to determine the amount of Henkaku tokens needed for register
の実装を試しました！

register前にフロントから必要なHenkakuの量（`amount`）を取得できるように、`amount`を計算する関数を`public view`で外に出してみました。